### PR TITLE
Modified JUnitTestExecutor to run tests in groups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.washington.cs.dt</groupId>
     <artifactId>dtdetector</artifactId>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <packaging>jar</packaging>
 
     <name>dtdetector</name>

--- a/src/main/java/edu/washington/cs/dt/util/JUnitTest.java
+++ b/src/main/java/edu/washington/cs/dt/util/JUnitTest.java
@@ -1,0 +1,65 @@
+package edu.washington.cs.dt.util;
+
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+
+public class JUnitTest {
+    private final String fullMethodName;
+    private final Class<?> clzName;
+    private final int i;
+    private final String junitMethod;
+
+    public JUnitTest(final String fullMethodName) throws ClassNotFoundException {
+        this(fullMethodName, 0);
+    }
+
+    public JUnitTest(final String fullMethodName, int i) throws ClassNotFoundException {
+        this.fullMethodName = fullMethodName;
+
+        final String className = fullMethodName.substring(0, this.fullMethodName.lastIndexOf("."));
+        this.clzName = Class.forName(className);
+
+        this.junitMethod = fullMethodName.substring(this.fullMethodName.lastIndexOf(".") + 1);
+
+        this.i = i;
+    }
+
+    public JUnitTest(String className, String junitMethod) {
+        try {
+            this.clzName = Class.forName(className);
+            this.fullMethodName = this.clzName.getName() + "." + junitMethod;
+            this.junitMethod = junitMethod;
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+        i = 0;
+    }
+
+    public boolean isClassCompatible() {
+        RunWith annotations = clzName.getAnnotation(RunWith.class);
+        return annotations == null || !annotations.value().getName().equals("org.junit.runners.Parameterized");
+    }
+
+    public JUnitTest(Class<?> clzName, String junitMethod) {
+        this.clzName = clzName;
+        this.fullMethodName = this.clzName.getName() + "." + junitMethod;
+        this.junitMethod = junitMethod;
+        i = 0;
+    }
+
+    public Description description() {
+        return Description.createTestDescription(clzName, junitMethod);
+    }
+
+    public String name() {
+        return fullMethodName;
+    }
+
+    public Class<?> testClass() {
+        return clzName;
+    }
+
+    public int index() {
+        return i;
+    }
+}

--- a/src/main/java/edu/washington/cs/dt/util/JUnitTestExecutor.java
+++ b/src/main/java/edu/washington/cs/dt/util/JUnitTestExecutor.java
@@ -207,10 +207,15 @@ class JUnitTestExecutor {
     private class TestOrderComparator implements Comparator<Description> {
         @Override
         public int compare(Description a, Description b) {
-            // Safe to not check for null on map access because we filtered first.
-            return Integer.compare(
-                    testMap.get(TestExecUtils.fullName(a)).index(),
-                    testMap.get(TestExecUtils.fullName(b)).index());
+            if (testMap.containsKey(TestExecUtils.fullName(a))) {
+                if (testMap.containsKey(TestExecUtils.fullName(b))) {
+                    return Integer.compare(
+                            testMap.get(TestExecUtils.fullName(a)).index(),
+                            testMap.get(TestExecUtils.fullName(b)).index());
+                }
+            }
+
+            return 0;
         }
     }
 }

--- a/src/main/java/edu/washington/cs/dt/util/JUnitTestExecutor.java
+++ b/src/main/java/edu/washington/cs/dt/util/JUnitTestExecutor.java
@@ -1,141 +1,216 @@
 /** Copyright 2012 University of Washington. All Rights Reserved.
- *  @author Sai Zhang
+ *  @author Sai Zhang, Reed Oei
  */
 package edu.washington.cs.dt.util;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
+import junit.framework.AssertionFailedError;
+import junit.framework.ComparisonFailure;
+import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;
+import org.junit.runner.Runner;
+import org.junit.runner.manipulation.Filter;
 import org.junit.runner.notification.Failure;
 
 import edu.washington.cs.dt.RESULT;
 import edu.washington.cs.dt.main.Main;
+import org.junit.runner.notification.RunListener;
 
 
 /**
  * This class is in too low level. I made it package-visible
- * on purpose. 
+ * on purpose.
  * */
 class JUnitTestExecutor {
+    private static final PrintStream EMPTY_STREAM = new PrintStream(new OutputStream() {
+        public void write(int b) {
+            //DO NOTHING
+        }
+    });
 
-	private String result = null;
-	private String stackTrace = TestExecUtils.noStackTrace;
-	private String fullStackTrace = TestExecUtils.noStackTrace;
-	
-	public final Class<?> junitTest;
-	public final String junitMethod;
-	public final String fullMethodName;
-	
-	private static final PrintStream EMPTY_STREAM = new PrintStream(new OutputStream() {
-		public void write(int b) {
-			//DO NOTHING
-		}
-	});
+	private final List<JUnitTest> testOrder = new ArrayList<>();
+    private final Map<String, JUnitTest> testMap = new HashMap<>();
+	private final Set<Class<?>> allClasses = new HashSet<>();
+	private final Set<JUnitTestResult> missingTests = new HashSet<>();
 
-	//package.class.method
-	public JUnitTestExecutor(String fullMethodName) throws ClassNotFoundException {
-		this.fullMethodName = fullMethodName;
-		String className = this.fullMethodName.substring(0, this.fullMethodName.lastIndexOf("."));
-		try {
-			Class<?> clzName = Class.forName(className);
-			this.junitTest = clzName;
-		} catch (ClassNotFoundException e) {
-			throw e;
-		}
-		this.junitMethod = this.fullMethodName.substring(this.fullMethodName.lastIndexOf(".") + 1);
-	}
+    public JUnitTestExecutor(final JUnitTest test) {
+        this(Collections.singletonList(test));
+    }
 
-	public JUnitTestExecutor(String className, String junitMethod) {
-		try {
-			Class<?> clzName = Class.forName(className);
-			this.junitTest = clzName;
-			this.junitMethod = junitMethod;
-			this.fullMethodName = this.junitTest.getName() + "." + junitMethod;
-		} catch (Throwable e) {
-			throw new RuntimeException(e);
-		}
-	}
+    public JUnitTestExecutor(final List<JUnitTest> tests) {
+        this(tests, new HashSet<JUnitTestResult>());
+    }
 
-	public boolean isClassCompatible() {
-		RunWith annotations = junitTest.getAnnotation(RunWith.class);
-		return annotations == null || !annotations.value().getName().equals("org.junit.runners.Parameterized");
-	}
-	
-	public JUnitTestExecutor(Class<?> junitTest, String junitMethod) {
-		this.junitTest = junitTest;
-		this.junitMethod = junitMethod;
-		this.fullMethodName = this.junitTest.getName() + "." + junitMethod;
-	}
+    public JUnitTestExecutor(final List<JUnitTest> tests, final Set<JUnitTestResult> missingTests) {
+        for (final JUnitTest test : tests) {
+            if (test.isClassCompatible()) {
+                testOrder.add(test);
+                allClasses.add(test.testClass());
+                testMap.put(test.name(), test);
+            } else {
+                System.out.println("  Detected incompatible test case with RunWith annotation.");
+            }
+        }
 
-	public void executeWithJUnit4Runner() {
+        this.missingTests.addAll(missingTests);
+    }
+
+    //package.class.method
+    public static JUnitTestExecutor singleton(final String fullMethodName) throws ClassNotFoundException {
+        return new JUnitTestExecutor(new JUnitTest(fullMethodName));
+    }
+
+    public static JUnitTestExecutor singleton(String className, String junitMethod) {
+        return new JUnitTestExecutor(new JUnitTest(className, junitMethod));
+    }
+
+    public static JUnitTestExecutor singleton(Class<?> junitTest, String junitMethod) {
+        return new JUnitTestExecutor(new JUnitTest(junitTest, junitMethod));
+    }
+
+    public static JUnitTestExecutor skipMissing(final List<String> testOrder) {
+        final List<JUnitTest> tests = new ArrayList<>();
+        final Set<JUnitTestResult> missingTests = new HashSet<>();
+
+        for (int i = 0; i < testOrder.size(); i++) {
+            final String fullMethodName = testOrder.get(i);
+            try {
+                final JUnitTest test = new JUnitTest(fullMethodName, i);
+
+                tests.add(test);
+            } catch (ClassNotFoundException e) {
+                missingTests.add(JUnitTestResult.missing(fullMethodName));
+                System.out.println("  Skipped missing test : " + fullMethodName);
+            }
+        }
+
+        return new JUnitTestExecutor(tests, missingTests);
+    }
+
+    public static JUnitTestExecutor testOrder(final List<String> testOrder) throws ClassNotFoundException {
+        final List<JUnitTest> tests = new ArrayList<>();
+
+        for (int i = 0; i < testOrder.size(); i++) {
+            final String fullMethodName = testOrder.get(i);
+            tests.add(new JUnitTest(fullMethodName, i));
+        }
+
+        return new JUnitTestExecutor(tests);
+    }
+
+    public Set<JUnitTestResult> executeWithJUnit4Runner(final boolean skipIncompatible) {
         JUnitCore core = new JUnitCore();
 
-		Request r = Request.method(this.junitTest, this.junitMethod);
+        final Request r = Request.classes(allClasses.toArray(new Class<?>[0]))
+                .filterWith(new TestOrderFilter())
+                .sortWith(new TestOrderComparator());
 
-		PrintStream currOut = System.out;
+        PrintStream currOut = System.out;
 		PrintStream currErr = System.err;
 
 		System.setOut(EMPTY_STREAM);
 		System.setErr(EMPTY_STREAM);
-		Result re = core.run(r);
+
+		final Map<String, Long> testRuntimes = new HashMap<>();
+		core.addListener(new TestTimeListener(testRuntimes));
 
 		System.setOut(currOut);
 		System.setErr(currErr);
 
-		//FIXME the run count can be > 1, e.g., testLazy in hibernate
-		if(re.getRunCount() > 1) {
-			Log.logln("FIXME: Running: " + this.junitMethod + ", count: " + re.getRunCount());
-		}
-		
-		if(re.getFailureCount() == 0) {
-			result = RESULT.PASS.name();
-		} else {
-			if(re.getFailureCount() > 1) {
-				//FIXME is there any nested test? so getFailureCount() will > 1
-				//e.g., running org.hibernate.test.annotations.id.sequences.JoinColumnOverrideTest.testBlownPrecision
-				//gives 2 failures
-				Log.logln("FIXME: Running: " + this.fullMethodName + ", failure count: " + re.getFailureCount());
-			}
-			//check whether it is a failure or an error
-            Failure f = re.getFailures().get(0);
-            Throwable excep = f.getException();
-            if(isJUnitAssertionFailure(excep)) {
-            	result = RESULT.FAILURE.name();
+		final Set<JUnitTestResult> results = new HashSet<>(missingTests);
+		final Map<String, JUnitTest> passingTests = new HashMap<>(testMap);
+
+        final Result re = core.run(r);
+		for (final Failure failure : re.getFailures()) {
+		    final String fullTestName = TestExecUtils.fullName(failure.getDescription());
+
+		    results.add(JUnitTestResult.failOrError(failure,
+                    testRuntimes.get(fullTestName),
+                    passingTests.get(fullTestName)));
+            passingTests.remove(fullTestName);
+        }
+
+        for (final String fullMethodName : passingTests.keySet()) {
+            results.add(JUnitTestResult.passing(testRuntimes.get(fullMethodName), passingTests.get(fullMethodName)));
+        }
+
+        return results;
+	}
+
+    private static class TestTimeListener extends RunListener {
+        private final Map<String, Long> times;
+        private final Map<String, Long> testRuntimes;
+
+        public TestTimeListener(Map<String, Long> testRuntimes) {
+            this.testRuntimes = testRuntimes;
+            times = new HashMap<>();
+        }
+
+        @Override
+        public void testStarted(Description description) throws Exception {
+            times.put(TestExecUtils.fullName(description), System.nanoTime());
+        }
+
+        @Override
+        public void testFinished(Description description) throws Exception {
+            final String fullTestName = TestExecUtils.fullName(description);
+
+            if (times.containsKey(fullTestName)) {
+                final long startTime = times.get(fullTestName);
+                testRuntimes.put(fullTestName, System.nanoTime() - startTime);
+                times.remove(fullTestName);
             } else {
-            	result = RESULT.ERROR.name();
+                System.out.println("Test finished but did not start: " + description.getDisplayName());
             }
-            //get the stack trace
-            stackTrace = flatStackTrace(excep);
-            fullStackTrace = TestExecUtils.flatStrings(TestExecUtils.extractStackTraces(excep));
-		}
-	}
-	
-	public static boolean isJUnitAssertionFailure(Throwable exception) {
-		return exception.getClass().equals(junit.framework.AssertionFailedError.class)
-		      || exception.getClass().equals(junit.framework.ComparisonFailure.class);
-	}
-	
-	public static String flatStackTrace(Throwable exception) {
-		String[] stacktraces = TestExecUtils.extractStackTraces(exception);
-		Pattern p = Pattern.compile(Main.excludeRegex);
-		String flatString = TestExecUtils.flatStrings(stacktraces, p, TestExecUtils.JUNIT_ASSERT);
-		return flatString;
-	}
-	
-	public String getResult() {
-		return this.result;
-	}
-	
-	public String getStackTrace() {
-		return this.stackTrace;
-	}
-	
-	public String getFullStackTrace() {
-		return this.fullStackTrace;
-	}
+        }
+    }
+
+    private class TestOrderFilter extends Filter {
+        @Override
+        public boolean shouldRun(final Description description) {
+            for (final JUnitTest test : testOrder) {
+                if (Filter.matchMethodDescription(test.description()).shouldRun(description)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        @Override
+        public String describe() {
+            // Return the order we are running in.
+            final List<String> testNames = new ArrayList<>();
+            for (final JUnitTest test : testOrder) {
+                testNames.add(test.name());
+            }
+
+            return testNames.toString();
+        }
+    }
+
+    private class TestOrderComparator implements Comparator<Description> {
+        @Override
+        public int compare(Description a, Description b) {
+            // Safe to not check for null on map access because we filtered first.
+            return Integer.compare(
+                    testMap.get(TestExecUtils.fullName(a)).index(),
+                    testMap.get(TestExecUtils.fullName(b)).index());
+        }
+    }
 }

--- a/src/main/java/edu/washington/cs/dt/util/JUnitTestExecutor.java
+++ b/src/main/java/edu/washington/cs/dt/util/JUnitTestExecutor.java
@@ -163,6 +163,7 @@ class JUnitTestExecutor {
 
         @Override
         public void testStarted(Description description) throws Exception {
+            System.out.println("Test being executed: " + TestExecUtils.fullName(description));
             times.put(TestExecUtils.fullName(description), System.nanoTime());
         }
 
@@ -175,7 +176,7 @@ class JUnitTestExecutor {
                 testRuntimes.put(fullTestName, System.nanoTime() - startTime);
                 times.remove(fullTestName);
             } else {
-                System.out.println("Test finished but did not start: " + description.getDisplayName());
+                System.out.println("Test finished but did not start: " + fullTestName);
             }
         }
     }

--- a/src/main/java/edu/washington/cs/dt/util/JUnitTestResult.java
+++ b/src/main/java/edu/washington/cs/dt/util/JUnitTestResult.java
@@ -1,0 +1,113 @@
+package edu.washington.cs.dt.util;
+
+import checkers.nullness.quals.Nullable;
+import edu.washington.cs.dt.RESULT;
+import edu.washington.cs.dt.main.Main;
+import junit.framework.AssertionFailedError;
+import junit.framework.ComparisonFailure;
+import org.junit.runner.notification.Failure;
+
+import java.util.regex.Pattern;
+
+public class JUnitTestResult {
+    private final String result;
+    private final String stackTrace;
+    private final String fullStackTrace;
+    private final long interval;
+
+    private final String testName;
+    @Nullable
+    private final JUnitTest test;
+
+    /**
+     * Private constructor, use the static methods to create instances (more descriptive names).
+     */
+    private JUnitTestResult(final String result,
+                            final String stackTrace,
+                            final String fullStackTrace,
+                            final long interval,
+                            final String testName,
+                            final JUnitTest test) {
+        this.result = result;
+        this.stackTrace = stackTrace;
+        this.fullStackTrace = fullStackTrace;
+        this.interval = interval;
+        this.testName = testName;
+        this.test = test;
+    }
+
+    public static JUnitTestResult passing(final Long interval, final JUnitTest test) {
+        return new JUnitTestResult(RESULT.PASS.name(),
+                TestExecUtils.noStackTrace,
+                TestExecUtils.noStackTrace,
+                interval,
+                test.name(),
+                test);
+    }
+
+    public static JUnitTestResult missing(final String fullMethodName) {
+        return new JUnitTestResult(RESULT.SKIPPED.name(),
+                TestExecUtils.noStackTrace,
+                TestExecUtils.noStackTrace,
+                -1,
+                fullMethodName,
+                null);
+    }
+
+    public static JUnitTestResult failOrError(final Failure failure,
+                                              final Long interval,
+                                              final JUnitTest test) {
+        final String result;
+        final String stackTrace;
+        final String fullStackTrace;
+
+        //check whether it is a failure or an error
+        final Throwable excep = failure.getException();
+        if(isJUnitAssertionFailure(excep)) {
+            result = RESULT.FAILURE.name();
+        } else {
+            result = RESULT.ERROR.name();
+        }
+
+        //get the stack trace
+        stackTrace = flatStackTrace(excep);
+        fullStackTrace = TestExecUtils.flatStrings(TestExecUtils.extractStackTraces(excep));
+
+        return new JUnitTestResult(result, stackTrace, fullStackTrace, interval, test.name(), test);
+    }
+
+    private static boolean isJUnitAssertionFailure(Throwable exception) {
+        return exception.getClass().equals(AssertionFailedError.class)
+              || exception.getClass().equals(ComparisonFailure.class);
+    }
+
+    public static String flatStackTrace(Throwable exception) {
+		String[] stacktraces = TestExecUtils.extractStackTraces(exception);
+		Pattern p = Pattern.compile(Main.excludeRegex);
+        return TestExecUtils.flatStrings(stacktraces, p, TestExecUtils.JUNIT_ASSERT);
+	}
+
+    public void output(StringBuilder sb) {
+        sb.append(test.name());
+        sb.append(TestExecUtils.timeSep);
+        sb.append(interval);
+        sb.append(TestExecUtils.testResultSep);
+        sb.append(result);
+        sb.append(TestExecUtils.resultExcepSep);
+        //			sb.append(stackTrace);
+        sb.append(fullStackTrace);
+        sb.append(Globals.lineSep);
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public String getStackTrace() {
+        return stackTrace;
+    }
+
+    public JUnitTest getTest() {
+        return test;
+    }
+}

--- a/src/main/java/edu/washington/cs/dt/util/SimpleTestRunner.java
+++ b/src/main/java/edu/washington/cs/dt/util/SimpleTestRunner.java
@@ -6,6 +6,8 @@ package edu.washington.cs.dt.util;
 import junit.framework.TestResult;
 import junit.textui.TestRunner;
 
+import java.util.Set;
+
 public class SimpleTestRunner {
 
 	public static void main(String[] args) {
@@ -24,13 +26,13 @@ public class SimpleTestRunner {
 			if (useJUnit4) {
 	            JUnitTestExecutor executor = null;
 	        	try {
-	                executor = new JUnitTestExecutor(fullTestName);
+	                executor = JUnitTestExecutor.singleton(fullTestName);
 	        	} catch (ClassNotFoundException e) {
 	        		e.printStackTrace();
 	        		System.exit(0);
 	        	}
-				executor.executeWithJUnit4Runner();
-				System.out.println("executing: ? " + fullTestName + ", successfully? " + executor.getResult());
+				final Set<JUnitTestResult> results = executor.executeWithJUnit4Runner(false);
+				System.out.println("executing: ? " + fullTestName + ", successfully? " + results.iterator().next().getResult());
 			} else {
 				try {
 					String[] junitArgs = new String[]{"-m", fullTestName};

--- a/src/main/java/edu/washington/cs/dt/util/TestExecUtils.java
+++ b/src/main/java/edu/washington/cs/dt/util/TestExecUtils.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 import junit.framework.TestFailure;
 
 import edu.washington.cs.dt.main.ImpactMain;
+import org.junit.runner.Description;
 import plume.Option;
 import edu.washington.cs.dt.OneTestExecResult;
 import edu.washington.cs.dt.RESULT;
@@ -365,5 +366,9 @@ public class TestExecUtils {
             return true;
         }
         return false;
+    }
+
+    public static String fullName(final Description description) {
+        return description.getClassName() + "." + description.getMethodName();
     }
 }

--- a/src/main/java/edu/washington/cs/dt/util/TestRunnerWrapper.java
+++ b/src/main/java/edu/washington/cs/dt/util/TestRunnerWrapper.java
@@ -5,6 +5,7 @@ package edu.washington.cs.dt.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 import junit.framework.TestFailure;
 import junit.framework.TestResult;
@@ -31,87 +32,75 @@ public class TestRunnerWrapper {
         }
         /*create the StringBuilder to output results*/
         StringBuilder sb = new StringBuilder();
-        /*create a test runner*/
-        TestRunner aTestRunner= new TestRunner();
+
+        try {
+            final JUnitTestExecutor executor = JUnitTestExecutor.testOrder(Arrays.asList(tests));
+            for (final JUnitTestResult result : executor.executeWithJUnit4Runner(false)) {
+                result.output(sb);
+            }
+
+            //if not exist, create it
+            File f = new File(outputFile);
+            if(!f.exists()) {
+                File dir = f.getParentFile();
+                boolean created = true;
+                if(dir != null && !dir.exists()) {
+                    created = dir.mkdirs();
+                }
+                created = created & f.createNewFile();
+                if(!created) {
+                    throw new RuntimeException("Cannot create: " + outputFile);
+                }
+            }
+            Files.writeToFile(sb.toString(), outputFile);
+            Files.writeToFile("", TestExecUtils.lockFile + (args.length > 2 ? args[2] : ""));
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        // This is old code for running JUnit 3 tests.
+        // However, it seems that JUnit 3 tests are actually compatible with JUnit 4, so there is no reason to have this.
+        /*
+        TestRunner aTestRunner = new TestRunner();
 
         long interval;
         for(String fullTestName : tests) {
         	System.out.println("Test being executed: " + fullTestName);
-        	boolean useJUnit4 = false;
-        	try {
-                useJUnit4 = CodeUtils.useJUnit4(fullTestName);
-        	} catch (ClassNotFoundException e) {
-        		Files.writeToFile("", TestExecUtils.exitFileName);
-        		e.printStackTrace();
-        		System.exit(0);
-        	}
-            /*check the results*/
             String result = null;
             //String stackTrace = TestExecUtils.noStackTrace;
             String fullStackTrace = TestExecUtils.noStackTrace;
-            if (useJUnit4) {
-                JUnitTestExecutor executor = null;
-            	try {
-                    executor = new JUnitTestExecutor(fullTestName);
-            	} catch (ClassNotFoundException e) {
-                    if (ImpactMain.skipMissingTests) {
-                        System.out.println("  Skipped missing test : " + fullTestName);
-                        sb.append(fullTestName);
-                        sb.append(TestExecUtils.timeSep);
-                        sb.append("-1");
-                        sb.append(TestExecUtils.testResultSep);
-                        sb.append("SKIPPED");
-                        sb.append(TestExecUtils.resultExcepSep);
-                        //			sb.append(stackTrace);
-                        sb.append(fullStackTrace);
-                        sb.append(Globals.lineSep);
-                        continue;
-                    } else {
-                        Files.writeToFile("", TestExecUtils.exitFileName);
-                        e.printStackTrace();
-                        System.exit(0);
-                    }
-            	}
+            try {
+                String[] junitArgs = new String[]{"-m", fullTestName};
+                // System.out.println(Utils.convertArrayToFlatString(junitArgs));
                 long start = System.nanoTime();
-                executor.executeWithJUnit4Runner();
+                TestResult r = aTestRunner.start(junitArgs);
                 interval = System.nanoTime() - start;
-                result = executor.getResult();
-                //stackTrace = executor.getStackTrace();
-                fullStackTrace = executor.getFullStackTrace();
-            } else {
-                try {
-                    String[] junitArgs = new String[]{"-m", fullTestName};
-                    // System.out.println(Utils.convertArrayToFlatString(junitArgs));
-                    long start = System.nanoTime();
-                    TestResult r = aTestRunner.start(junitArgs);
-                    interval = System.nanoTime() - start;
-                    if (r.wasSuccessful()) {
-                        result = RESULT.PASS.name();
-                    } else {
-                        if (r.errorCount() > 0) {
-                            Utils.checkTrue(r.errorCount() == 1,
-                                    "Only execute 1 test: " + fullTestName + ", two errors: "
-                                            + CodeUtils.flattenFailrues(r.errors()));
-                            result = RESULT.ERROR.name();
-                            TestFailure failure = r.errors().nextElement();
-                            //stackTrace = TestExecUtils.flatStackTrace(failure, Main.excludeRegex);
-                            fullStackTrace = TestExecUtils.flatStrings(TestExecUtils.extractStackTraces(failure.thrownException()));
-                        }
-                        if (r.failureCount() > 0) {
-                            Utils.checkTrue(r.failureCount() == 1,
-                                    "Only execute 1 test: " + fullTestName + ", two failures: "
-                                            + CodeUtils.flattenFailrues(r.failures()));
-                            result = RESULT.FAILURE.name();
-                            TestFailure failure = r.failures().nextElement();
-                            //stackTrace = TestExecUtils.flatStackTrace(failure,
-                            //		Main.excludeRegex);
-                            fullStackTrace = TestExecUtils.flatStrings(TestExecUtils.extractStackTraces(failure.thrownException()));
-                        }
+                if (r.wasSuccessful()) {
+                    result = RESULT.PASS.name();
+                } else {
+                    if (r.errorCount() > 0) {
+                        Utils.checkTrue(r.errorCount() == 1,
+                                "Only execute 1 test: " + fullTestName + ", two errors: "
+                                        + CodeUtils.flattenFailrues(r.errors()));
+                        result = RESULT.ERROR.name();
+                        TestFailure failure = r.errors().nextElement();
+                        //stackTrace = TestExecUtils.flatStackTrace(failure, Main.excludeRegex);
+                        fullStackTrace = TestExecUtils.flatStrings(TestExecUtils.extractStackTraces(failure.thrownException()));
                     }
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    throw new RuntimeException(e);
+                    if (r.failureCount() > 0) {
+                        Utils.checkTrue(r.failureCount() == 1,
+                                "Only execute 1 test: " + fullTestName + ", two failures: "
+                                        + CodeUtils.flattenFailrues(r.failures()));
+                        result = RESULT.FAILURE.name();
+                        TestFailure failure = r.failures().nextElement();
+                        //stackTrace = TestExecUtils.flatStackTrace(failure,
+                        //		Main.excludeRegex);
+                        fullStackTrace = TestExecUtils.flatStrings(TestExecUtils.extractStackTraces(failure.thrownException()));
+                    }
                 }
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw new RuntimeException(e);
             }
 
             sb.append(fullTestName);
@@ -124,6 +113,7 @@ public class TestRunnerWrapper {
             sb.append(fullStackTrace);
             sb.append(Globals.lineSep);
         }
+
         //if not exist, create it
         File f = new File(outputFile);
         if(!f.exists()) {
@@ -139,6 +129,7 @@ public class TestRunnerWrapper {
         }
         Files.writeToFile(sb.toString(), outputFile);
         Files.writeToFile("", TestExecUtils.lockFile);
+        */
     }
 
 }

--- a/src/main/java/edu/washington/cs/dt/util/TestRunnerWrapperFileInputs.java
+++ b/src/main/java/edu/washington/cs/dt/util/TestRunnerWrapperFileInputs.java
@@ -50,77 +50,39 @@ public class TestRunnerWrapperFileInputs {
         }
 
         int testsExecuted = 0;
-        /*create the StringBuilder to output results*/
-        StringBuilder sb = new StringBuilder();
-        for(String fullTestName : tests) {
-        	System.out.println("Test being executed: " + fullTestName);
+        try {
+            final JUnitTestExecutor executor;
+            if (skipMissingTests) {
+                executor = JUnitTestExecutor.skipMissing(tests);
+            } else {
+                executor = JUnitTestExecutor.testOrder(tests);
+            }
 
-            /*check the results*/
-            String result = null;
-            //			String stackTrace = TestExecUtils.noStackTrace;
-            String fullStackTrace = TestExecUtils.noStackTrace;
+            /*create the StringBuilder to output results*/
+            StringBuilder sb = new StringBuilder();
+            for (final JUnitTestResult result : executor.executeWithJUnit4Runner(skipIncompatibleTests)) {
+                result.output(sb);
+                testsExecuted++;
+            }
 
-            JUnitTestExecutor executor = null;
-        	try {
-                executor = new JUnitTestExecutor(fullTestName);
-        	} catch (ClassNotFoundException e) {
-        	    if (skipMissingTests) {
-                    System.out.println("  Skipped missing test : " + fullTestName);
-                    sb.append(fullTestName);
-                    sb.append(TestExecUtils.timeSep);
-                    sb.append("-1");
-                    sb.append(TestExecUtils.testResultSep);
-                    sb.append("SKIPPED");
-                    sb.append(TestExecUtils.resultExcepSep);
-                    //			sb.append(stackTrace);
-                    sb.append(fullStackTrace);
-                    sb.append(Globals.lineSep);
-                    continue;
-                } else {
-                    Files.writeToFile("", TestExecUtils.exitFileName+args[2]);
-                    e.printStackTrace();
-                    System.exit(0);
+            //if not exist, create it
+            File f = new File(outputFile);
+            if(!f.exists()) {
+                File dir = f.getParentFile();
+                boolean created = true;
+                if(dir != null && !dir.exists()) {
+                    created = dir.mkdirs();
                 }
-        	}
-
-			if (skipIncompatibleTests && !executor.isClassCompatible()) {
-				System.out.println("  Detected incompatible test case with RunWith annotation.");
-				continue;
-			}
-
-			testsExecuted += 1;
-            long start = System.nanoTime();
-            executor.executeWithJUnit4Runner();
-            long interval = System.nanoTime() - start;
-            result = executor.getResult();
-            //				stackTrace = executor.getStackTrace();
-            fullStackTrace = executor.getFullStackTrace();
-
-            sb.append(fullTestName);
-            sb.append(TestExecUtils.timeSep);
-            sb.append(interval);
-            sb.append(TestExecUtils.testResultSep);
-            sb.append(result);
-            sb.append(TestExecUtils.resultExcepSep);
-            //			sb.append(stackTrace);
-            sb.append(fullStackTrace);
-            sb.append(Globals.lineSep);
-        }
-        //if not exist, create it
-        File f = new File(outputFile);
-        if(!f.exists()) {
-            File dir = f.getParentFile();
-            boolean created = true;
-            if(dir != null && !dir.exists()) {
-                created = dir.mkdirs();
+                created = created & f.createNewFile();
+                if(!created) {
+                    throw new RuntimeException("Cannot create: " + outputFile);
+                }
             }
-            created = created & f.createNewFile();
-            if(!created) {
-                throw new RuntimeException("Cannot create: " + outputFile);
-            }
+            Files.writeToFile(sb.toString(), outputFile);
+            Files.writeToFile("", TestExecUtils.lockFile + (args.length > 2 ? args[2] : ""));
+        } catch (ClassNotFoundException e) {
+            e.printStackTrace();
         }
-        Files.writeToFile(sb.toString(), outputFile);
-        Files.writeToFile("", TestExecUtils.lockFile + (args.length > 2 ? args[2] : ""));
         return testsExecuted;
     }
 }

--- a/src/main/java/edu/washington/cs/dt/util/TestRunnerWrapperFileInputs.java
+++ b/src/main/java/edu/washington/cs/dt/util/TestRunnerWrapperFileInputs.java
@@ -100,7 +100,7 @@ public class TestRunnerWrapperFileInputs {
             }
         }
         Files.writeToFile(sb.toString(), outputFile);
-        Files.writeToFile("", TestExecUtils.lockFile+args[2]);
+        Files.writeToFile("", TestExecUtils.lockFile + (args.length > 2 ? args[2] : ""));
         return testsExecuted;
     }
 }

--- a/tests/edu/washington/cs/dt/samples/junit4x/ExampleJunit4xTest.java
+++ b/tests/edu/washington/cs/dt/samples/junit4x/ExampleJunit4xTest.java
@@ -3,11 +3,13 @@
  */
 package edu.washington.cs.dt.samples.junit4x;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
 import junit.framework.Assert;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
@@ -21,6 +23,13 @@ public class ExampleJunit4xTest {
 
 	static int x = 1;
 
+	private static List<Integer> list = new ArrayList<>();
+
+	@BeforeClass
+	public static void beforeClass() {
+		list.add(1);
+	}
+
 	@Test
 	public void testX() {
 		x++;
@@ -33,13 +42,16 @@ public class ExampleJunit4xTest {
 		System.out.println("Running testY");
 	}
 
-        /*
 	@Test
 	public void testZ() {
 		System.out.println("Throw exception");
 		throw new RuntimeException();
 	}
-        */
+
+	@Test
+	public void test1() {
+		Assert.assertEquals(1, list.size());
+	}
 
         /*
 	@Test

--- a/tests/edu/washington/cs/dt/util/TestJUnitTestExecutor.java
+++ b/tests/edu/washington/cs/dt/util/TestJUnitTestExecutor.java
@@ -10,84 +10,93 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
 public class TestJUnitTestExecutor extends TestCase {
 
 	public static Test suite() {
 		return new TestSuite(TestJUnitTestExecutor.class);
 	}
 
+	private static JUnitTestResult singletonResult(final JUnitTestExecutor executor) {
+	    return executor.executeWithJUnit4Runner(false).iterator().next();
+    }
+
 	public void testPassJUnit3() {
-		JUnitTestExecutor executor = new JUnitTestExecutor(SampleJUnit3Tests.class, "testJUnit3_1");
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.PASS.name(), executor.getResult());
-		assertEquals(TestExecUtils.noStackTrace, executor.getStackTrace());
+		JUnitTestExecutor executor = JUnitTestExecutor.singleton(SampleJUnit3Tests.class, "testJUnit3_1");
+		JUnitTestResult result = singletonResult(executor);
+		assertEquals(RESULT.PASS.name(), result.getResult());
+		assertEquals(TestExecUtils.noStackTrace, result.getStackTrace());
 
 		try {
-			executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.SampleJUnit3Tests.testJUnit3_1");
+			executor = JUnitTestExecutor.singleton("edu.washington.cs.dt.samples.SampleJUnit3Tests.testJUnit3_1");
 		} catch (ClassNotFoundException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.PASS.name(), executor.getResult());
-		assertTrue(TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+        result = singletonResult(executor);
+		assertEquals(RESULT.PASS.name(), result.getResult());
+		assertTrue(TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
-		executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.SampleJUnit3Tests", "testJUnit3_1");
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.PASS.name(), executor.getResult());
-		assertTrue(TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		executor = JUnitTestExecutor.singleton("edu.washington.cs.dt.samples.SampleJUnit3Tests", "testJUnit3_1");
+		result = singletonResult(executor);
+		assertEquals(RESULT.PASS.name(), result.getResult());
+		assertTrue(TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 	}
 
 	public void testPassJUnit4() {
-		JUnitTestExecutor executor = new JUnitTestExecutor(ExampleJunit4xTest.class, "testX");
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.PASS.name(), executor.getResult());
-		assertEquals(TestExecUtils.noStackTrace, executor.getStackTrace());
+		JUnitTestExecutor executor = JUnitTestExecutor.singleton(ExampleJunit4xTest.class, "testX");
+		JUnitTestResult result = singletonResult(executor);
+		assertEquals(RESULT.PASS.name(), result.getResult());
+		assertEquals(TestExecUtils.noStackTrace, result.getStackTrace());
 
 		try {
-			executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testX");
+			executor = JUnitTestExecutor.singleton("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testX");
 		} catch (ClassNotFoundException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.PASS.name(), executor.getResult());
-		assertTrue(TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+        result = singletonResult(executor);
+		assertEquals(RESULT.PASS.name(), result.getResult());
+		assertTrue(TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
-		executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest", "testX");
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.PASS.name(), executor.getResult());
-		assertTrue(TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		executor = JUnitTestExecutor.singleton("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest", "testX");
+        result = singletonResult(executor);
+		assertEquals(RESULT.PASS.name(), result.getResult());
+		assertTrue(TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 	}
 
 	public void testJUnit3WithException() {
-		JUnitTestExecutor executor = new JUnitTestExecutor(SampleJUnit3Tests.class, "testJUnit3_exception");
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.ERROR.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		JUnitTestExecutor executor = JUnitTestExecutor.singleton(SampleJUnit3Tests.class, "testJUnit3_exception");
+        JUnitTestResult result = singletonResult(executor);
+		assertEquals(RESULT.ERROR.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
 		try {
-			executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.SampleJUnit3Tests.testJUnit3_exception");
+			executor = JUnitTestExecutor.singleton("edu.washington.cs.dt.samples.SampleJUnit3Tests.testJUnit3_exception");
 		} catch (ClassNotFoundException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.ERROR.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		result = singletonResult(executor);
+		assertEquals(RESULT.ERROR.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
-		executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.SampleJUnit3Tests", "testJUnit3_exception");
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.ERROR.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		executor = JUnitTestExecutor.singleton("edu.washington.cs.dt.samples.SampleJUnit3Tests", "testJUnit3_exception");
+		result = singletonResult(executor);
+		assertEquals(RESULT.ERROR.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 	}
 
         /*
 	public void testFail1JUnit4() {
 		JUnitTestExecutor executor = new JUnitTestExecutor(ExampleJunit4xTest.class, "testE");
 		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.FAILURE.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		assertEquals(RESULT.FAILURE.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
 		try {
 			executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testE");
@@ -96,44 +105,44 @@ public class TestJUnitTestExecutor extends TestCase {
 			e.printStackTrace();
 		}
 		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.FAILURE.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		assertEquals(RESULT.FAILURE.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
 		executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest", "testE");
 		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.FAILURE.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		assertEquals(RESULT.FAILURE.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 	}
         */
 
 	public void testJUnit3WithFailure() {
-		JUnitTestExecutor executor = new JUnitTestExecutor(SampleJUnit3Tests.class, "testJUnit3_fail");
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.FAILURE.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		JUnitTestExecutor executor = JUnitTestExecutor.singleton(SampleJUnit3Tests.class, "testJUnit3_fail");
+        JUnitTestResult result = singletonResult(executor);
+		assertEquals(RESULT.FAILURE.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
 		try {
-			executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.SampleJUnit3Tests.testJUnit3_fail");
+			executor = JUnitTestExecutor.singleton("edu.washington.cs.dt.samples.SampleJUnit3Tests.testJUnit3_fail");
 		} catch (ClassNotFoundException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.FAILURE.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		result = singletonResult(executor);
+		assertEquals(RESULT.FAILURE.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
-		executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.SampleJUnit3Tests", "testJUnit3_fail");
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.FAILURE.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		executor = JUnitTestExecutor.singleton("edu.washington.cs.dt.samples.SampleJUnit3Tests", "testJUnit3_fail");
+		result = singletonResult(executor);
+		assertEquals(RESULT.FAILURE.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 	}
 
         /*
 	public void testFail2JUnit4() {
 		JUnitTestExecutor executor = new JUnitTestExecutor(ExampleJunit4xTest.class, "testF");
 		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.FAILURE.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		assertEquals(RESULT.FAILURE.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
 		try {
 			executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testF");
@@ -142,36 +151,61 @@ public class TestJUnitTestExecutor extends TestCase {
 			e.printStackTrace();
 		}
 		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.FAILURE.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		assertEquals(RESULT.FAILURE.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
 		executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest", "testF");
 		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.FAILURE.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		assertEquals(RESULT.FAILURE.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 	}
         */
 
 	public void testErrorJUnit4() {
-		JUnitTestExecutor executor = new JUnitTestExecutor(ExampleJunit4xTest.class, "testZ");
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.ERROR.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		JUnitTestExecutor executor = JUnitTestExecutor.singleton(ExampleJunit4xTest.class, "testZ");
+        JUnitTestResult result = singletonResult(executor);
+		assertEquals(RESULT.ERROR.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
 		try {
-			executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testZ");
+			executor = JUnitTestExecutor.singleton("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testZ");
 		} catch (ClassNotFoundException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.ERROR.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		result = singletonResult(executor);
+		assertEquals(RESULT.ERROR.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 
-		executor = new JUnitTestExecutor("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest", "testZ");
-		executor.executeWithJUnit4Runner();
-		assertEquals(RESULT.ERROR.name(), executor.getResult());
-		assertTrue(!TestExecUtils.noStackTrace.equals(executor.getStackTrace()));
+		executor = JUnitTestExecutor.singleton("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest", "testZ");
+		result = singletonResult(executor);
+		assertEquals(RESULT.ERROR.name(), result.getResult());
+		assertTrue(!TestExecUtils.noStackTrace.equals(result.getStackTrace()));
 	}
 
+	public void testRunMultipleJUnit4() throws ClassNotFoundException {
+		final JUnitTestExecutor executor = JUnitTestExecutor.testOrder(
+				Arrays.asList(
+						"edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testZ",
+						"edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testX",
+						"edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.test1"
+				)
+		);
+
+		final Set<JUnitTestResult> results = executor.executeWithJUnit4Runner(false);
+
+		assertEquals(3, results.size());
+
+		for (final JUnitTestResult result : results) {
+		    if (result.getTest().name().equals("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.test1")) {
+		        assertEquals(RESULT.PASS.name(), result.getResult());
+            } else if (result.getTest().name().equals("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testX")) {
+                assertEquals(RESULT.PASS.name(), result.getResult());
+            } else if (result.getTest().name().equals("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testZ")) {
+                assertEquals(RESULT.ERROR.name(), result.getResult());
+            } else {
+		        fail("Unexpected test run: " + result.getTest().name());
+            }
+        }
+	}
 }


### PR DESCRIPTION
Modified JUnitTestExecutor to run tests in groups instead of one at the time. The reason for this change is that if tests are run one at a time, then the `@BeforeClass` and `@AfterClass` methods in those test classes will be run once for each test executed. The fix is therefore to make JUnit produce the desired test order and run them all at the same time, so that the result is identical to what would be seen if JUnit ran the tests in the order given. 

The changes that do this are in the `JUnitTestExecutor` class. The `JUnitTest` and `JUnitTestResult` classes are essentially just data classes. The changes to the `TestRunnerWrapper` classes were necessary because the way that the `JUnitTestExecutor` has significantly changed.

A test has been added which tests this capability (in `TestJUnitTestExecutor`).

Files modified:
```
src/main/java/edu/washington/cs/dt/util/JUnitTestExecutor.java
src/main/java/edu/washington/cs/dt/util/SimpleTestRunner.java
src/main/java/edu/washington/cs/dt/util/TestExecUtils.java
src/main/java/edu/washington/cs/dt/util/TestRunnerWrapper.java
src/main/java/edu/washington/cs/dt/util/TestRunnerWrapperFileInputs.java
tests/edu/washington/cs/dt/samples/junit4x/ExampleJunit4xTest.java
tests/edu/washington/cs/dt/util/TestJUnitTestExecutor.java
```

Files added:
```
src/main/java/edu/washington/cs/dt/util/JUnitTest.java
src/main/java/edu/washington/cs/dt/util/JUnitTestResult.java
```