### PR TITLE
Re-enable ability to run tests separately.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.washington.cs.dt</groupId>
     <artifactId>dtdetector</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
     <packaging>jar</packaging>
 
     <name>dtdetector</name>

--- a/src/main/java/edu/washington/cs/dt/main/ImpactMain.java
+++ b/src/main/java/edu/washington/cs/dt/main/ImpactMain.java
@@ -24,6 +24,7 @@ public class ImpactMain {
 
     public static boolean useTimer = false;
     public static boolean skipMissingTests = false;
+    public static boolean runSeparately = false;
 
     public static void main(String[] args) {
         // list to parse the arguments
@@ -76,6 +77,7 @@ public class ImpactMain {
 
         boolean randomize = argsList.contains("-randomize");
         skipMissingTests = argsList.contains("-skipMissingTests");
+        runSeparately = argsList.contains("-separate");
 
 
         boolean do_not_fork_test_execution = argsList.contains("-doNotForkTestExecution");

--- a/src/main/java/edu/washington/cs/dt/util/JUnitTest.java
+++ b/src/main/java/edu/washington/cs/dt/util/JUnitTest.java
@@ -1,6 +1,7 @@
 package edu.washington.cs.dt.util;
 
 import org.junit.runner.Description;
+import org.junit.runner.Request;
 import org.junit.runner.RunWith;
 
 public class JUnitTest {
@@ -61,5 +62,13 @@ public class JUnitTest {
 
     public int index() {
         return i;
+    }
+
+    public String methodName() {
+        return junitMethod;
+    }
+
+    public Request request() {
+        return Request.method(clzName, junitMethod);
     }
 }

--- a/src/main/java/edu/washington/cs/dt/util/JUnitTestResult.java
+++ b/src/main/java/edu/washington/cs/dt/util/JUnitTestResult.java
@@ -55,7 +55,7 @@ public class JUnitTestResult {
     }
 
     public static JUnitTestResult failOrError(final Failure failure,
-                                              final Long interval,
+                                              final long interval,
                                               final JUnitTest test) {
         final String result;
         final String stackTrace;

--- a/src/main/java/edu/washington/cs/dt/util/TestExecUtils.java
+++ b/src/main/java/edu/washington/cs/dt/util/TestExecUtils.java
@@ -101,6 +101,10 @@ public class TestExecUtils {
             commandList.add("-skipMissingTests");
         }
 
+        if (ImpactMain.runSeparately) {
+            commandList.add("-separate");
+        }
+
         //        }
 
         String[] args = commandList.toArray(new String[0]);
@@ -221,6 +225,11 @@ public class TestExecUtils {
         if (ImpactMain.skipMissingTests) {
             commandList.add("-skipMissingTests");
         }
+
+        if (ImpactMain.runSeparately) {
+            commandList.add("-separate");
+        }
+
 //        }
 
         String[] args = commandList.toArray(new String[0]);

--- a/src/main/java/edu/washington/cs/dt/util/TestRunnerWrapper.java
+++ b/src/main/java/edu/washington/cs/dt/util/TestRunnerWrapper.java
@@ -30,12 +30,12 @@ public class TestRunnerWrapper {
         for(int index = 1; index < args.length; index++) {
             tests[index - 1] = args[index];
         }
+
         /*create the StringBuilder to output results*/
         StringBuilder sb = new StringBuilder();
 
         try {
-            final JUnitTestExecutor executor = JUnitTestExecutor.testOrder(Arrays.asList(tests));
-            for (final JUnitTestResult result : executor.executeWithJUnit4Runner(false)) {
+            for (final JUnitTestResult result : JUnitTestExecutor.runOrder(Arrays.asList(tests), false, false, false)) {
                 result.output(sb);
             }
 

--- a/src/main/java/edu/washington/cs/dt/util/TestRunnerWrapperFileInputs.java
+++ b/src/main/java/edu/washington/cs/dt/util/TestRunnerWrapperFileInputs.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import edu.washington.cs.dt.main.ImpactMain;
 
@@ -41,6 +42,7 @@ public class TestRunnerWrapperFileInputs {
 
         boolean skipIncompatibleTests = argsList.contains("-skipIncompatibleTests");
         boolean skipMissingTests = argsList.contains("-skipMissingTests");
+        boolean runSeparately = argsList.contains("-separate");
 
         List<String> tests = new LinkedList<String>();
         for(String line : content) {
@@ -51,16 +53,9 @@ public class TestRunnerWrapperFileInputs {
 
         int testsExecuted = 0;
         try {
-            final JUnitTestExecutor executor;
-            if (skipMissingTests) {
-                executor = JUnitTestExecutor.skipMissing(tests);
-            } else {
-                executor = JUnitTestExecutor.testOrder(tests);
-            }
-
             /*create the StringBuilder to output results*/
             StringBuilder sb = new StringBuilder();
-            for (final JUnitTestResult result : executor.executeWithJUnit4Runner(skipIncompatibleTests)) {
+            for (final JUnitTestResult result : JUnitTestExecutor.runOrder(tests, skipMissingTests, skipIncompatibleTests, runSeparately)) {
                 result.output(sb);
                 testsExecuted++;
             }

--- a/tests/edu/washington/cs/dt/samples/junit4x/ExampleBeforeClassTests.java
+++ b/tests/edu/washington/cs/dt/samples/junit4x/ExampleBeforeClassTests.java
@@ -1,0 +1,28 @@
+package edu.washington.cs.dt.samples.junit4x;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ExampleBeforeClassTests {
+    public static final List<Integer> xs = new ArrayList<>();
+
+    @BeforeClass
+    public static void beforeClass() {
+        xs.add(1);
+    }
+
+    @Test
+    public void testXsHasOneItemAndAddOne() {
+        Assert.assertEquals(1, xs.size());
+        xs.add(2);
+    }
+
+    @Test
+    public void testXsHasTwoItems() {
+        Assert.assertEquals(2, xs.size());
+    }
+}

--- a/tests/edu/washington/cs/dt/util/TestJUnitTestExecutor.java
+++ b/tests/edu/washington/cs/dt/util/TestJUnitTestExecutor.java
@@ -5,14 +5,18 @@ package edu.washington.cs.dt.util;
 
 import edu.washington.cs.dt.RESULT;
 import edu.washington.cs.dt.samples.SampleJUnit3Tests;
+import edu.washington.cs.dt.samples.junit4x.ExampleBeforeClassTests;
 import edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest;
+import junit.framework.Assert;
 import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class TestJUnitTestExecutor extends TestCase {
@@ -207,5 +211,42 @@ public class TestJUnitTestExecutor extends TestCase {
 		        fail("Unexpected test run: " + result.getTest().name());
             }
         }
+	}
+
+	public void testRunSeparateAndTogether() throws ClassNotFoundException {
+		final List<String> testOrder =
+            Arrays.asList(
+                    "edu.washington.cs.dt.samples.junit4x.ExampleBeforeClassTests.testXsHasOneItemAndAddOne",
+                    "edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testX",
+                    "edu.washington.cs.dt.samples.junit4x.ExampleBeforeClassTests.testXsHasTwoItems"
+            );
+
+		final JUnitTestExecutor executor = JUnitTestExecutor.testOrder(testOrder);
+		final Map<String, String> expectedJUnitRunner = new HashMap<>();
+
+		expectedJUnitRunner.put("edu.washington.cs.dt.samples.junit4x.ExampleBeforeClassTests.testXsHasOneItemAndAddOne", RESULT.PASS.name());
+		expectedJUnitRunner.put("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testX", RESULT.PASS.name());
+		expectedJUnitRunner.put("edu.washington.cs.dt.samples.junit4x.ExampleBeforeClassTests.testXsHasTwoItems", RESULT.PASS.name());
+
+		final Map<String, String> expectedSeparate = new HashMap<>();
+
+		expectedSeparate.put("edu.washington.cs.dt.samples.junit4x.ExampleBeforeClassTests.testXsHasOneItemAndAddOne", RESULT.PASS.name());
+		expectedSeparate.put("edu.washington.cs.dt.samples.junit4x.ExampleJunit4xTest.testX", RESULT.PASS.name());
+		expectedSeparate.put("edu.washington.cs.dt.samples.junit4x.ExampleBeforeClassTests.testXsHasTwoItems", RESULT.ERROR.name());
+
+		checkExpected(expectedJUnitRunner, executor.executeWithJUnit4Runner(false));
+
+		// Need to clear the state between runs.
+		ExampleBeforeClassTests.xs.clear();
+
+		checkExpected(expectedSeparate, executor.executeSeparately(false));
+	}
+
+	private void checkExpected(final Map<String, String> expected, final Set<JUnitTestResult> results) {
+		Assert.assertEquals(expected.size(), results.size());
+
+		for (final JUnitTestResult result : results) {
+			Assert.assertEquals(expected.get(result.getTest().name()), result.getResult());
+		}
 	}
 }


### PR DESCRIPTION
Re-enable ability to run tests separately, with each test being run by a separate call to the JUnit API. Running tests this way will cause @BeforeClass and @AfterClass methods to be run multiple times for same class. This behavior can be enable by passing the `-separate` flag to `ImpactMain` or `TestRunnerWrapperFileInputs`.

Pull request was tested manually and with a new test (`TestJUnitTestExecutor.testRunSeparateAndTogether`).

Files added:
```
tests/edu/washington/cs/dt/samples/junit4x/ExampleBeforeClassTests.java
```

Files modified:
```
pom.xml
src/main/java/edu/washington/cs/dt/main/ImpactMain.java
src/main/java/edu/washington/cs/dt/util/JUnitTest.java
src/main/java/edu/washington/cs/dt/util/JUnitTestExecutor.java
src/main/java/edu/washington/cs/dt/util/JUnitTestResult.java
src/main/java/edu/washington/cs/dt/util/TestExecUtils.java
src/main/java/edu/washington/cs/dt/util/TestRunnerWrapper.java
src/main/java/edu/washington/cs/dt/util/TestRunnerWrapperFileInputs.java
tests/edu/washington/cs/dt/util/TestJUnitTestExecutor.java
```